### PR TITLE
Adds `mermaid` and github theme `highlight.js` for code formatting along with `Fire` managed args to mkposter

### DIFF
--- a/mkposters/__main__.py
+++ b/mkposters/__main__.py
@@ -1,7 +1,7 @@
-import sys
+import fire
 
 from .mkposter import mkposter
 
 
-_, filename = sys.argv
-mkposter(filename)
+if __name__ == "__main__":
+    fire.Fire(mkposter)

--- a/mkposters/custom.scss
+++ b/mkposters/custom.scss
@@ -47,7 +47,3 @@ hr {
 .md-typeset ul li {
     margin-bottom: 0;
 }
-
-body {
-    background-color: #F6F6EF;
-}

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -42,6 +42,10 @@ def mkposter(
         port (int): The port to use for the server.
     Returns:
         Rendered markdown as HTML via `http.server` on specified port.
+    Example:
+        ```bash
+        python -m mkposters "research_app/poster" --code_style "github" --background_color "#F6F6EF" --port 8000
+        ```
     """
 
     with tempfile.TemporaryDirectory() as tempdir:

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -27,7 +27,7 @@ def md_to_html(md):
     )
 
 
-def mkposter(datadir, code_style="github"):
+def mkposter(datadir, code_style="github", background_color="#F6F6EF"):
     with tempfile.TemporaryDirectory() as tempdir:
         tempdir = pathlib.Path(tempdir)
         datadir = pathlib.Path(datadir)
@@ -50,6 +50,7 @@ def mkposter(datadir, code_style="github"):
         html_out = rf"""<!doctype html>
         <html>
         <head>
+        <body style="background-color:{background_color}">
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700%7CRoboto+Mono&amp;display=fallback">
         <link rel="stylesheet" type="text/css" href="style.css"/>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/{code_style}.min.css">

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 
 import markdown
+from pymdownx.superfences import fence_div_format
 
 from .post_install import post_install
 
@@ -16,6 +17,13 @@ def md_to_html(md):
     return markdown.markdown(
         md,
         extensions=["admonition", "pymdownx.superfences", "smarty"],
+        extension_configs={
+            "pymdownx.superfences": {
+                "custom_fences": [
+                    {"name": "mermaid", "class": "mermaid", "format": fence_div_format}
+                ]
+            }
+        },
     )
 
 
@@ -47,6 +55,9 @@ def mkposter(datadir, code_style="github"):
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/{code_style}.min.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
         <script>hljs.initHighlightingOnLoad();</script>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.css">
+        <script src="https://unpkg.com/mermaid@9.0.1/dist/mermaid.min.js"></script>
+        <script>mermaid.initialize();</script>
         <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
         <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
         </head>

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -27,7 +27,23 @@ def md_to_html(md):
     )
 
 
-def mkposter(datadir, code_style="github", background_color="#F6F6EF"):
+def mkposter(
+    datadir: str,
+    code_style: str = "github",
+    background_color: str = "#FFFFFF",
+    port: int = 8000,
+):
+    """
+    Make a poster from a Markdown file.
+    Args:
+        datadir (str): The directory containing the Markdown file.
+        code_style (str): The style of code blocks.
+        background_color (str): The background color of the poster.
+        port (int): The port to use for the server.
+    Returns:
+        Rendered markdown as HTML via `http.server` on specified port.
+    """
+
     with tempfile.TemporaryDirectory() as tempdir:
         tempdir = pathlib.Path(tempdir)
         datadir = pathlib.Path(datadir)
@@ -108,4 +124,5 @@ def mkposter(datadir, code_style="github", background_color="#F6F6EF"):
         with html_file.open("w") as f:
             f.write(html_out)
 
-        subprocess.run(["python", "-m", "http.server"], cwd=tempdir)
+        serve_cmd = f"python -m http.server {port}"
+        subprocess.run(serve_cmd.split(" "), cwd=tempdir)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ classifiers = [
 
 python_requires = "~=3.7"
 
-install_requires = ["markdown>=3.3.6", "pymdown-extensions>=9.1"]
+install_requires = ["markdown>=3.3.6", "pymdown-extensions>=9.1", "fire>=0.4.0"]
 
 setuptools.setup(
     name=name,


### PR DESCRIPTION
Adds:
- `mermaid.js` diagram support
- code rendering with `highlight.js`, default github theme
- pass arguments to mkposter using `Fire`
    - adds `background_color` str argument with default `#FFFFFF`
    - adds `code_style` str arg for `highlight.js` themes with default 'github'
    - adds `port` int arg to specify `http.server` port, with 8000 as default.

Example:
```bash
python -m mkposters "research_app/poster" --code_style "github" --background_color "#F6F6EF" --port 8000
```